### PR TITLE
Wrap "ctypes.windll" in "try"

### DIFF
--- a/example/font.py
+++ b/example/font.py
@@ -25,7 +25,10 @@ def load() -> int:
     '''
     :return: default font
     '''
-    ctypes.windll.shcore.SetProcessDpiAwareness(1)
+    try:
+        ctypes.windll.shcore.SetProcessDpiAwareness(1)
+    except:
+        pass
 
     dpg_markdown.set_font_registry(dpg.add_font_registry())
     dpg_markdown.set_add_font_function(add_font)


### PR DESCRIPTION
`ctypes.windll.shcore.SetProcessDpiAwareness(1)` gives error outside Windows. Catch it.